### PR TITLE
Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # Installation
 
-    npm install sqlpatch -g
+``` sh
+ $ npm install sqlpatch -g
+```
 
 
 # Usage
 
-    sqlpatch sqlfile1.sql sqlfile2.sql > output.sql
+``` sh
+ $ sqlpatch [--dialect=postgres] db/alters/*.sql > db/release.sql
+```
+
+> Note, `postgres` and `sqlserver` only are dialects available at the moment;
+> `postgres` is the default dialect.
 
 
 # What's this?
@@ -17,7 +24,9 @@ a script that will execute all new SQL files in the right order.
 
 You may specify a dependency using the following syntax:
 
-    -- @require dependency
+``` sql
+ -- @require dependency
+```
 
 Where dependency is a file name, without the extension or directory.
 
@@ -25,6 +34,16 @@ SQLPatch will first sort these SQL files based on their dependencies. Then it
 will wrap some SQL code around it so that you can just dump the generated SQL
 in your database and be sure that every statement is execute in the right order.
 
+To give the dependency a different name, regardless of the file name:
+
+``` sql
+ -- @name custom_dependency_name
+```
+
+Then require the dependency using its new name:
+
+``` sql
+ -- @require custom_dependency_name
+```
+
 [Check out the examples!](./examples)
-
-

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "sqlpatch": "cli"
   },
   "dependencies": {
-    "extend": "~2.0.0",
-    "glob": "^5.0.5",
+    "glob": "^5.0.6",
     "mustache": "^2.0.0",
     "nopt": "~3.0.1",
     "toposort": "~0.2.10"

--- a/src/sqlpatch.js
+++ b/src/sqlpatch.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 var path = require('path');
 var pkg = require('../package');
 var toposort = require('toposort');
-var extend = require('extend');
+var extend = require('util')._extend;
 var Mustache = require('mustache');
 
 function sqlpatch(fileList, writer, options) {


### PR DESCRIPTION
Summary: avoid using of deep copy on arguments, documentation enhancement.

Looks like Node's built-in util._extend(), that does a shallow copy, is quite suitable. Though it is undocumented utility method used for Nodejs internal purposes, why not to avoid using yet another additional module?
If I misunderstand something, and a deep copy is something that is really need then probably it is safer to use a shallow copy with module xtend? Thanks!
